### PR TITLE
Make "expertplus" string lowercase in "diffNames" vector

### DIFF
--- a/src/Types/LevelButtons.cpp
+++ b/src/Types/LevelButtons.cpp
@@ -433,7 +433,7 @@ void ButtonsContainer::RefreshHighlightedDifficulties() {
             // attempt to find difficulty
             LOWER(difficulty.Name);
             int diff = -1;
-            static const std::vector<std::string> diffNames = {"easy", "normal", "hard", "expert", "expertPlus"};
+            static const std::vector<std::string> diffNames = {"easy", "normal", "hard", "expert", "expertplus"};
             for(int i = 0; i < diffNames.size(); i++) {
                 if(diffNames[i] == difficulty.Name) {
                     diff = i;


### PR DESCRIPTION
fixes bug where no specified expert+ difficulties in playlists would be highlighted due to a capitalisation mismatch when comparing strings